### PR TITLE
Recipe routes added to routes.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resources :recipes, only: [:index, :show, :new, :create]
 end


### PR DESCRIPTION
The README states that "The models and show routes and associations have been set up for you" but the routes.rb file was empty. Added routes for index, show, new, and create controllers.